### PR TITLE
Run aliases

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 // Place your settings in this file to overwrite default and user settings.
 {
+    
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,16 @@
     ],
     "main": "./src/extension",
     "contributes": {
+        "configuration":{
+            "title": "Smallworld GIS path",
+            "properties": {
+                "Smallworld.gisPath":{
+                "type": ["string", "null"],
+                "default": "C:\\Smallworld\\430\\product\\bin\\x86\\gis.exe",
+                "description": "Specifies the path of gis.exe that the project uses. **USE double backslash \\ **"
+                }
+            }
+        },
         "themes": [
             {
                 "label": "Smallworld Magik",
@@ -83,7 +93,22 @@
                 "language": "magik",
                 "path": "./snippets/magik.snippets.json"
             }
+        ],        
+
+        "commands": [
+            {
+            "command": "swSessions.runaliases",
+            "title": "sw:Run GIS Alias"
+            }
+        ],
+        "menus": {
+        "editor/context": [
+            {
+            "command": "swSessions.runaliases",
+            "group": "swGroup@1"
+            }
         ]
+        }   
     },
     "bugs": {
 		"url": "https://github.com/siamz/smallworld-magik-vscode.git/issues",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
             "properties": {
                 "Smallworld.gisPath":{
                 "type": ["string", "null"],
-                "default": "C:\\Smallworld\\430\\product\\bin\\x86\\gis.exe",
-                "description": "Specifies the path of gis.exe that the project uses. **USE double backslash \\ **"
+                "default": "C:/Smallworld/430/product/bin/x86/gis.exe",
+                "description": "Specifies the path of gis.exe that the project uses. **USE double backslash '\\' or single foreward slash '/'**"
                 }
             }
         },
@@ -98,15 +98,14 @@
         "commands": [
             {
             "command": "swSessions.runaliases",
-            "title": "sw: Run GIS Alias"
+            "title": "GIS Run Alias"
             }
         ],
         "menus": {
         "editor/context": [
             {
             "command": "swSessions.runaliases",
-            "group": "swGroup@1",
-            "title": "Run GIS Alias"
+            "group": "swGroup@1"
             }
         ]
         }   

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "smallworld-magik",
     "displayName": "Smallworld Magik",
     "description": "Smallworld Magik for Visual Studio Code",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "publisher": "siamz",
     "icon": "images/swmagik.png",
 	"keywords": [

--- a/package.json
+++ b/package.json
@@ -98,14 +98,15 @@
         "commands": [
             {
             "command": "swSessions.runaliases",
-            "title": "sw:Run GIS Alias"
+            "title": "sw: Run GIS Alias"
             }
         ],
         "menus": {
         "editor/context": [
             {
             "command": "swSessions.runaliases",
-            "group": "swGroup@1"
+            "group": "swGroup@1",
+            "title": "Run GIS Alias"
             }
         ]
         }   

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
                 "Smallworld.gisPath":{
                 "type": ["string", "null"],
                 "default": "C:/Smallworld/430/product/bin/x86/gis.exe",
-                "description": "Specifies the path of gis.exe that the project uses. **USE double backslash '\\' or single foreward slash '/'**"
+                "description": "Specifies the path of gis.exe that the project uses. **USE double backslash '\\' or single foreward slash '/'** \n \"Smallworld.gisPath\": \"gis path\" "
                 }
             }
         },

--- a/src/extension.js
+++ b/src/extension.js
@@ -20,6 +20,16 @@ function activate(context) {
     vscode.languages.registerDocumentSymbolProvider('magik', symbolProvider);
     vscode.languages.registerDocumentSymbolProvider('swgis', symbolProvider);
 
+    //button click run aliases
+    
+    let disposable = vscode.commands.registerCommand(
+        "swSessions.runaliases",
+        function() {
+        gAl.runaliases();
+        }
+      );
+
+
 }
 exports.activate = activate;
 // this method is called when your extension is deactivated

--- a/src/gisAliases.js
+++ b/src/gisAliases.js
@@ -64,17 +64,18 @@ class swSessions{
             //Currently the tab of the alias file needs to be opened.
             var currentOpenTabFilePath = vscode.window.activeTextEditor.document.fileName;
             //Get gis.exe path
-            const gisPath = workbenchConfig.get('gisPath');
+            var gisPath = workbenchConfig.get('gisPath');
 
             //Get the selected text(alias).
-            const selectedAlias = editor.document.getText(editor.selection);
+            var selectedAlias = editor.document.getText(editor.selection);
 
             //Show some messages.
             vscode.window.showInformationMessage('Smallworld GIS Starting...');
-            vscode.window.showInformationMessage('using alias: ' + selectedAlias + ' ' + currentOpenTabFilePath);
+            vscode.window.showInformationMessage('using alias: ' + selectedAlias);
            
             //Start Smallworld with the correct alias
            var execCommand = gisPath +  ' -a ' + currentOpenTabFilePath + ' ' + selectedAlias;
+           vscode.window.showInformationMessage(execCommand);
            exec(execCommand, (err, stdout, stderr) => { 
             if (err)
                 return console.error(err);

--- a/src/gisAliases.js
+++ b/src/gisAliases.js
@@ -1,7 +1,6 @@
 'use strict';
 const vscode = require('vscode');
 const { exec } = require('child_process');
-const path = require('path');
 const workbenchConfig = vscode.workspace.getConfiguration('Smallworld')
 const editor = vscode.window.activeTextEditor;
 
@@ -61,20 +60,21 @@ class swSessions{
     runaliases(alias){        
         try
         {
+            let activeEditor = vscode.window.activeTextEditor;
             //Currently the tab of the alias file needs to be opened.
-            var currentOpenTabFilePath = vscode.window.activeTextEditor.document.fileName;
+            var currentOpenTabFilePath = activeEditor.document.fileName;
             //Get gis.exe path
             var gisPath = workbenchConfig.get('gisPath');
             console.log("path: " + gisPath);
             //Get the selected text(alias).
-            var selectedAlias = editor.document.getText(editor.selection);
+            var selectedAlias = activeEditor.document.getText(activeEditor.selection);
 
             //Show some messages.
             vscode.window.showInformationMessage('Smallworld GIS Starting...');
             vscode.window.showInformationMessage('using alias: ' + selectedAlias);
            
             //Start Smallworld with the correct alias
-           var execCommand = gisPath +  ' -a ' + currentOpenTabFilePath + ' ' + selectedAlias;
+           var execCommand = gisPath +  ' -a ' + "\"" + currentOpenTabFilePath + "\""+ ' ' + selectedAlias;
            vscode.window.showInformationMessage(execCommand);
            exec(execCommand, (err, stdout, stderr) => { 
             if (err)

--- a/src/gisAliases.js
+++ b/src/gisAliases.js
@@ -1,6 +1,9 @@
 'use strict';
 const vscode = require('vscode');
 const { exec } = require('child_process');
+const path = require('path');
+const workbenchConfig = vscode.workspace.getConfiguration('Smallworld')
+const editor = vscode.window.activeTextEditor;
 
 class swSessions{
     run(context) {
@@ -55,14 +58,34 @@ class swSessions{
         }
     }
     
-    runaliases(alias){
-        vscode.window.showInformationMessage('Smallworld GIS Starting...');
-        exec('D:\\WDI\\Core430\\product\\bin\\x86\\gis.exe -a D:\\WDI\\adjust.IT432\\config\\gis_aliases open', (err, stdout, stderr) => {
+    runaliases(alias){        
+        try
+        {
+            //Currently the tab of the alias file needs to be opened.
+            var currentOpenTabFilePath = vscode.window.activeTextEditor.document.fileName;
+            //Get gis.exe path
+            const gisPath = workbenchConfig.get('gisPath');
+
+            //Get the selected text(alias).
+            const selectedAlias = editor.document.getText(editor.selection);
+
+            //Show some messages.
+            vscode.window.showInformationMessage('Smallworld GIS Starting...');
+            vscode.window.showInformationMessage('using alias: ' + selectedAlias + ' ' + currentOpenTabFilePath);
+           
+            //Start Smallworld with the correct alias
+           var execCommand = gisPath +  ' -a ' + currentOpenTabFilePath + ' ' + selectedAlias;
+           exec(execCommand, (err, stdout, stderr) => { 
             if (err)
-               return console.error(err);
-           else 
-               console.log(stdout);
-        });
+                return console.error(err);
+            else 
+                console.log(stdout);
+            });
+        }
+         catch(err)
+        {
+            vscode.window.showInformationMessage(err.message);  
+        }
     }
 }
 exports.swSessions = swSessions    

--- a/src/gisAliases.js
+++ b/src/gisAliases.js
@@ -65,7 +65,7 @@ class swSessions{
             var currentOpenTabFilePath = vscode.window.activeTextEditor.document.fileName;
             //Get gis.exe path
             var gisPath = workbenchConfig.get('gisPath');
-
+            console.log("path: " + gisPath);
             //Get the selected text(alias).
             var selectedAlias = editor.document.getText(editor.selection);
 


### PR DESCRIPTION
Modified runaliases. You can start a smallworld session by double clicking the alias name and then right click and select Run alias from the context menu.
For this to work you need to set you gis.exe path in the settings.
This is tested with Smallworld 4.3 and Smallworld 5.1.9
`
{
    "Smallworld.gisPath": "{your sw install directory}/gis.exe"
}
`